### PR TITLE
Use a less restrictive address->coordinate lookup service

### DIFF
--- a/fabric_network/rotterdam_logistics_blocklab/rest_client/config/default.json
+++ b/fabric_network/rotterdam_logistics_blocklab/rest_client/config/default.json
@@ -10,6 +10,9 @@
   "graph-hopper": {
     "api-key": "6b7aac66-6fc7-470f-949e-e66adb7c9584"
   },
+  "mapquest": {
+    "api-key": "3dThpjGAT6XCRytVTjqljbnGnNbcGG9M"
+  },
   "ComposerConfig": {
      "debug": {
        "logger": "default",

--- a/fabric_network/rotterdam_logistics_blocklab/rest_client/distance/DistanceService.js
+++ b/fabric_network/rotterdam_logistics_blocklab/rest_client/distance/DistanceService.js
@@ -10,7 +10,8 @@ class DistanceService
 {
 	constructor()
 	{
-		this.apiKey = config["graph-hopper"]["api-key"];
+		this.graphhopperApiKey = config["graph-hopper"]["api-key"];
+		this.mapquestApiKey = config["mapquest"]["api-key"];
 	}
 
 	/**
@@ -38,7 +39,7 @@ class DistanceService
 		const params = {
 			point: [pointFrom, pointTo],
 			type: 'json',
-			key: this.apiKey,
+			key: this.graphhopperApiKey,
 			vehicle: "car", // truck not allowed in free tier
 			instructions: false, // just the distance
 			calc_points: false // just the distance
@@ -69,9 +70,10 @@ class DistanceService
 	{
 		const queryObject = address.toQueryObject();
 		queryObject.format = "json";
+		queryObject.key = this.mapquestApiKey;
 
 		let result = await request.defaults({
-			uri: 'https://nominatim.openstreetmap.org/search',
+			uri: 'http://open.mapquestapi.com/nominatim/v1/search.php',
 			qs: queryObject,
 			headers : {
 				accept: 'application/json'


### PR DESCRIPTION
We were blocked by the free, open OSMN Nominatim service as our init-network-with-test-data was generating too many calls.

Hence a PR for any future team picking this work up.